### PR TITLE
Don't create a reshaped array when compute a Jacobian of a StaticVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,8 @@ julia = "1.2"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "BlockBandedMatrices", "BandedMatrices", "Pkg", "SafeTestsets"]

--- a/src/FiniteDiff.jl
+++ b/src/FiniteDiff.jl
@@ -8,6 +8,10 @@ import Base: resize!
 _vec(x) = vec(x)
 _vec(x::Number) = x
 
+_mat(x::AbstractMatrix) = x
+_mat(x::StaticVector)   = reshape(x, (axes(x, 1), SOneTo(1)))
+_mat(x::AbstractVector) = reshape(x, (axes(x, 1),  OneTo(1)))
+
 include("iteration_utils.jl")
 include("epsilons.jl")
 include("derivatives.jl")

--- a/test/out_of_place_tests.jl
+++ b/test/out_of_place_tests.jl
@@ -16,28 +16,45 @@ function second_derivative_stencil(N)
 end
 
 x = @SVector ones(30)
-J = FiniteDiff.finite_difference_jacobian(f,x, Val{:forward}, eltype(x))
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x))
 @test J ≈ second_derivative_stencil(30)
 
-J = FiniteDiff.finite_difference_jacobian(f,x, Val{:central}, eltype(x))
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:central}, eltype(x))
 @test J ≈ second_derivative_stencil(30)
 
-J = FiniteDiff.finite_difference_jacobian(f,x, Val{:complex}, eltype(x))
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:complex}, eltype(x))
 @test J ≈ second_derivative_stencil(30)
 
 spJ = sparse(second_derivative_stencil(30))
-J = FiniteDiff.finite_difference_jacobian(f,x, Val{:forward}, eltype(x),jac_prototype=spJ)
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x), jac_prototype=spJ)
 @test J ≈ second_derivative_stencil(30)
 @test typeof(J) == typeof(spJ)
-J = FiniteDiff.finite_difference_jacobian(f,x, Val{:forward}, eltype(x),colorvec=repeat(1:3,10),sparsity=spJ,jac_prototype=spJ)
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x),
+    colorvec=SVector{30}(repeat(1:3, 10)), sparsity=spJ, jac_prototype=spJ)
 @test J ≈ second_derivative_stencil(30)
 @test typeof(J) == typeof(spJ)
+
 #1x1 SVector test
 x = SVector{1}([1.])
 f(x) = x
 J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x))
-@test J ≈ SMatrix{1,1}([1.])
+@test J[1, 1] ≈ 1.0
+@test J isa SMatrix{1,1}
 J = FiniteDiff.finite_difference_jacobian(f, x, Val{:central}, eltype(x))
-@test J ≈ SMatrix{1,1}([1.])
+@test J[1, 1] ≈ 1.0
+@test J isa SMatrix{1,1}
 J = FiniteDiff.finite_difference_jacobian(f, x, Val{:complex}, eltype(x))
-@test J ≈ SMatrix{1,1}([1.])
+@test J[1, 1] ≈ 1.0
+@test J isa SMatrix{1,1}
+
+x = SVector{1}([1.])
+f(x) = vcat(x, x)
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x))
+@test J ≈ fill(1.0, 2, 1)
+@test J isa SMatrix{2,1}
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:central}, eltype(x))
+@test J ≈ fill(1.0, 2, 1)
+@test J isa SMatrix{2,1}
+J = FiniteDiff.finite_difference_jacobian(f, x, Val{:complex}, eltype(x))
+@test J ≈ fill(1.0, 2, 1)
+@test J isa SMatrix{2,1}


### PR DESCRIPTION
valued function of size one. It causes very inefficient fallbacks
```julia
julia> reshape(SMatrix{1,1}(1.0), 1, 1)
1×1 reshape(::SArray{Tuple{1,1},Float64,2,1}, 1, 1) with eltype Float64:
 1.0

julia> reshape(SMatrix{1,1}(1.0), 1, 1)*1.0
1×1 Array{Float64,2}:
 1.0
```

Fixes https://github.com/JuliaDiff/FiniteDiff.jl/issues/104