### PR TITLE
Fix calculation of 1x1 Jacobian of a Vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FiniteDiff
 
 [![Build Status](https://travis-ci.org/JuliaDiff/FiniteDiff.jl.svg?branch=master)](https://travis-ci.org/JuliaDiff/FiniteDiff.jl)
+[![codecov](https://codecov.io/gh/JuliaDiff/FiniteDiff.jl/branch/master/graph/badge.svg?token=PnBAscoOiU)](https://codecov.io/gh/JuliaDiff/FiniteDiff.jl)
 
 This package is for calculating derivatives, gradients, Jacobians, Hessians,
 etc. numerically. This library is for maximizing speed while giving a usable

--- a/src/FiniteDiff.jl
+++ b/src/FiniteDiff.jl
@@ -9,8 +9,8 @@ _vec(x) = vec(x)
 _vec(x::Number) = x
 
 _mat(x::AbstractMatrix) = x
-_mat(x::StaticVector)   = reshape(x, (axes(x, 1), SOneTo(1)))
-_mat(x::AbstractVector) = reshape(x, (axes(x, 1),  OneTo(1)))
+_mat(x::StaticVector)   = reshape(x, (axes(x, 1),     SOneTo(1)))
+_mat(x::AbstractVector) = reshape(x, (axes(x, 1), Base.OneTo(1)))
 
 include("iteration_utils.jl")
 include("epsilons.jl")

--- a/test/out_of_place_tests.jl
+++ b/test/out_of_place_tests.jl
@@ -34,7 +34,7 @@ J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x),
 @test J ≈ second_derivative_stencil(30)
 @test typeof(J) == typeof(spJ)
 
-f = x -> x
+f(x) = x
 @testset "1x1 test of $x" for
   (x, y) in ((SVector{1}([1.]), SMatrix{1,1}), ([1.0], Matrix)),
     difftype in (:forward, :central, :complex)

--- a/test/out_of_place_tests.jl
+++ b/test/out_of_place_tests.jl
@@ -34,18 +34,15 @@ J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x),
 @test J ≈ second_derivative_stencil(30)
 @test typeof(J) == typeof(spJ)
 
-#1x1 SVector test
-x = SVector{1}([1.])
-f(x) = x
-J = FiniteDiff.finite_difference_jacobian(f, x, Val{:forward}, eltype(x))
-@test J[1, 1] ≈ 1.0
-@test J isa SMatrix{1,1}
-J = FiniteDiff.finite_difference_jacobian(f, x, Val{:central}, eltype(x))
-@test J[1, 1] ≈ 1.0
-@test J isa SMatrix{1,1}
-J = FiniteDiff.finite_difference_jacobian(f, x, Val{:complex}, eltype(x))
-@test J[1, 1] ≈ 1.0
-@test J isa SMatrix{1,1}
+f = x -> x
+@testset "1x1 test of $x" for
+  (x, y) in ((SVector{1}([1.]), SMatrix{1,1}), ([1.0], Matrix)),
+    difftype in (:forward, :central, :complex)
+
+  J = FiniteDiff.finite_difference_jacobian(f, x, Val{difftype}, eltype(x))
+  @test J[1, 1] ≈ 1.0
+  @test J isa y
+end
 
 x = SVector{1}([1.])
 f(x) = vcat(x, x)


### PR DESCRIPTION
The call to `OneTo` had to be qualified. This wasn't noticed because the case didn't have coverage so I've extended the tests to cover the case and also added the Codecov badge to make it easier to find the coverage info.