### PR TITLE
Add fast path for _colorediteration! with sparse J

### DIFF
--- a/src/iteration_utils.jl
+++ b/src/iteration_utils.jl
@@ -32,20 +32,10 @@ end
 _use_findstructralnz(sparsity) = ArrayInterface.has_sparsestruct(sparsity)
 _use_findstructralnz(::SparseMatrixCSC) = false
 
-# test if J, sparsity are both SparseMatrixCSC and have the same size storage arrays,
-# if so, update J so they can share the same sparsity pattern
-_use_sparseCSC_common_sparsity!(J, sparsity) = false
-function _use_sparseCSC_common_sparsity!(J::SparseMatrixCSC, sparsity::SparseMatrixCSC)
-    common_sparsity = (length(J.colptr) == length(sparsity.colptr) &&
-            length(J.nzval) == length(sparsity.nzval))
-
-    if common_sparsity
-        J.colptr .= sparsity.colptr
-        J.rowval .= sparsity.rowval
-    end
-
-    return common_sparsity
-end
+# test if J, sparsity are both SparseMatrixCSC and have the same sparsity pattern of stored values
+_use_sparseCSC_common_sparsity(J, sparsity) = false
+_use_sparseCSC_common_sparsity(J::SparseMatrixCSC, sparsity::SparseMatrixCSC) =
+    ((J.colptr == sparsity.colptr) && (J.rowval == sparsity.rowval))
 
 function __init__()
     @require BlockBandedMatrices="ffab5731-97b5-5995-9138-79e8c1846df0" begin

--- a/src/iteration_utils.jl
+++ b/src/iteration_utils.jl
@@ -16,9 +16,36 @@ end
     end
 end
 
+# fast version for the case where J and sparsity have the same sparsity pattern
+@inline function _colorediteration!(Jsparsity::SparseMatrixCSC,vfx,colorvec,color_i,ncols)
+    @inbounds for col_index in 1:ncols
+        if colorvec[col_index] == color_i
+            @inbounds for spidx in nzrange(Jsparsity, col_index)
+                row_index = Jsparsity.rowval[spidx]
+                Jsparsity.nzval[spidx]=vfx[row_index]
+            end
+        end
+    end
+end
+
 #override default setting of using findstructralnz
 _use_findstructralnz(sparsity) = ArrayInterface.has_sparsestruct(sparsity)
 _use_findstructralnz(::SparseMatrixCSC) = false
+
+# test if J, sparsity are both SparseMatrixCSC and have the same size storage arrays,
+# if so, update J so they can share the same sparsity pattern
+_use_sparseCSC_common_sparsity!(J, sparsity) = false
+function _use_sparseCSC_common_sparsity!(J::SparseMatrixCSC, sparsity::SparseMatrixCSC)
+    common_sparsity = (length(J.colptr) == length(sparsity.colptr) &&
+            length(J.nzval) == length(sparsity.nzval))
+
+    if common_sparsity
+        J.colptr .= sparsity.colptr
+        J.rowval .= sparsity.rowval
+    end
+
+    return common_sparsity
+end
 
 function __init__()
     @require BlockBandedMatrices="ffab5731-97b5-5995-9138-79e8c1846df0" begin

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -348,8 +348,8 @@ function finite_difference_jacobian!(
         fill!(J,false)
     end
 
-    # fast path if J and sparsity are both SparseMatrixCSC and have the same number of columns and stored values
-    sparseCSC_common_sparsity = _use_sparseCSC_common_sparsity!(J, sparsity)
+    # fast path if J and sparsity are both SparseMatrixCSC and have the same sparsity pattern
+    sparseCSC_common_sparsity = _use_sparseCSC_common_sparsity(J, sparsity)
     
     if fdtype == Val(:forward)
         vfx1 = _vec(fx1)


### PR DESCRIPTION
Partial fix for https://github.com/JuliaDiff/SparseDiffTools.jl/issues/138
https://github.com/JuliaDiff/SparseDiffTools.jl/issues/100

Adds a fast path for the case where J and sparsity are are both
SparseMatrixCSC and have the same sparsity pattern