### PR TITLE
Make sparse non-square Jacobians work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDiff"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.11.0"
+version = "2.11.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
I had trouble using FiniteDiff to calculate a non-square sparse Jacobian. It looks like the code dealing with sparse Jacobians assumes the input and output arguments are the same length, specifically when determining an appropriate step size. Fixing that makes things work.