### PR TITLE
Make `finite_difference_jacobian` work with range argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDiff"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.12.1"
+version = "2.12.2"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -1,8 +1,8 @@
-mutable struct JacobianCache{CacheType1,CacheType2,CacheType3,ColorType,SparsityType,fdtype,returntype}
+mutable struct JacobianCache{CacheType1,CacheType2,CacheType3,CacheType4,ColorType,SparsityType,fdtype,returntype}
     x1  :: CacheType1
-    x2  :: CacheType1
-    fx  :: CacheType2
-    fx1 :: CacheType3
+    x2  :: CacheType2
+    fx  :: CacheType3
+    fx1 :: CacheType4
     colorvec :: ColorType
     sparsity :: SparsityType
 end
@@ -98,7 +98,7 @@ function JacobianCache(
         _fx = fx
     end
     _x2 = zero(_x1)
-    JacobianCache{typeof(_x1),typeof(_fx),typeof(fx1),typeof(colorvec),typeof(sparsity),fdtype,returntype}(_x1,_x2,_fx,fx1,colorvec,sparsity)
+    JacobianCache{typeof(_x1),typeof(_x2),typeof(_fx),typeof(fx1),typeof(colorvec),typeof(sparsity),fdtype,returntype}(_x1,_x2,_fx,fx1,colorvec,sparsity)
 end
 
 function _make_Ji(::SparseMatrixCSC, rows_index,cols_index,dx,colorvec,color_i,nrows,ncols)
@@ -157,14 +157,14 @@ void_setindex!(args...) = (setindex!(args...); return)
 function finite_difference_jacobian(
     f,
     x,
-    cache::JacobianCache{T1,T2,T3,cType,sType,fdtype,returntype},
+    cache::JacobianCache{T1,T2,T3,T4,cType,sType,fdtype,returntype},
     f_in=nothing;
     relstep=default_relstep(fdtype, eltype(x)),
     absstep=relstep,
     colorvec = cache.colorvec,
     sparsity = cache.sparsity,
     jac_prototype = nothing,
-    dir=true) where {T1,T2,T3,cType,sType,fdtype,returntype}
+    dir=true) where {T1,T2,T3,T4,cType,sType,fdtype,returntype}
 
     x1, fx, fx1 = cache.x1, cache.fx, cache.fx1
 
@@ -325,13 +325,13 @@ function finite_difference_jacobian!(
     J,
     f,
     x,
-    cache::JacobianCache{T1,T2,T3,cType,sType,fdtype,returntype},
+    cache::JacobianCache{T1,T2,T3,T4,cType,sType,fdtype,returntype},
     f_in = nothing;
     relstep = default_relstep(fdtype, eltype(x)),
     absstep = relstep,
     colorvec = cache.colorvec,
     sparsity = cache.sparsity,
-    dir = true) where {T1,T2,T3,cType,sType,fdtype,returntype}
+    dir = true) where {T1,T2,T3,T4,cType,sType,fdtype,returntype}
 
     m, n = size(J)
     _color = reshape(colorvec, axes(x)...)


### PR DESCRIPTION
This PR makes it possible to call the out-of-place Jacobian function with a range input, e.g.,

```
julia> using FiniteDiff

julia> f(x) = @. x^2 + sin(x)
f (generic function with 1 method)

julia> x = 0.0:0.1:1.0
0.0:0.1:1.0

julia> FiniteDiff.finite_difference_jacobian(f, x)
11×11 Matrix{Float64}:
 1.0  0.0    0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0
 0.0  1.195  0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0
 0.0  0.0    1.38007  0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0
 0.0  0.0    0.0      1.55534  0.0      0.0      0.0      0.0      0.0      0.0      0.0
 0.0  0.0    0.0      0.0      1.72106  0.0      0.0      0.0      0.0      0.0      0.0
 0.0  0.0    0.0      0.0      0.0      1.87758  0.0      0.0      0.0      0.0      0.0
 0.0  0.0    0.0      0.0      0.0      0.0      2.02534  0.0      0.0      0.0      0.0
 0.0  0.0    0.0      0.0      0.0      0.0      0.0      2.16484  0.0      0.0      0.0
 0.0  0.0    0.0      0.0      0.0      0.0      0.0      0.0      2.29671  0.0      0.0
 0.0  0.0    0.0      0.0      0.0      0.0      0.0      0.0      0.0      2.42161  0.0
 0.0  0.0    0.0      0.0      0.0      0.0      0.0      0.0      0.0      0.0      2.5403

julia>
```

This used to be possible, but (I think) I broke this functionality with a recent PR for non-square sparse Jacobians (https://github.com/JuliaDiff/FiniteDiff.jl/pull/133), where I changed the definition of `JacobianCache` from this:

```
mutable struct JacobianCache{CacheType1,CacheType2,CacheType3,ColorType,SparsityType,fdtype,returntype}
    x1  :: CacheType1
    fx  :: CacheType2
    fx1 :: CacheType3
    colorvec :: ColorType
    sparsity :: SparsityType
end
```

to this:

```
mutable struct JacobianCache{CacheType1,CacheType2,CacheType3,ColorType,SparsityType,fdtype,returntype}
    x1  :: CacheType1
    x2  :: CacheType1
    fx  :: CacheType3
    fx1 :: CacheType4
    colorvec :: ColorType
    sparsity :: SparsityType
end
```

Requiring the `x1` and `x2` fields to be the same type was the source of the bug. Changing `JacobianCache` to

```
mutable struct JacobianCache{CacheType1,CacheType2,CacheType3,CacheType4,ColorType,SparsityType,fdtype,returntype}
    x1  :: CacheType1
    x2  :: CacheType2
    fx  :: CacheType3
    fx1 :: CacheType4
    colorvec :: ColorType
    sparsity :: SparsityType
end
```

fixed things. I added some simple tests to `test/finitedifftests.jl`.