### PR TITLE
non mutating gradient

### DIFF
--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -130,7 +130,12 @@ function finite_difference_gradient(
         end
     end
     cache = GradientCache(df, x, fdtype, returntype, inplace)
-    finite_difference_gradient!(df, f, x, cache, relstep=relstep, absstep=absstep, dir=dir)
+    if typeof(x) <: AbstractArray && fdtype == Val(:central)
+        df = finite_difference_gradient(f, x, cache, relstep=relstep, absstep=absstep, dir=dir)
+    else
+        df = finite_difference_gradient!(df,f, x, cache, relstep=relstep, absstep=absstep, dir=dir)
+    end
+    return df
 end
 
 function finite_difference_gradient!(
@@ -169,6 +174,29 @@ end
 
 # vector of derivatives of a vector->scalar map by each component of a vector x
 # this ignores the value of "inplace", because it doesn't make much sense
+function finite_difference_gradient(
+    f,
+    x::AbstractVector{<:Number},
+    cache::GradientCache{T1,T2,T3,T4,fdtype,returntype,inplace};
+    relstep=default_relstep(fdtype, eltype(x)),
+    absstep=relstep,
+    dir=true) where {T1,T2,T3,T4,fdtype,returntype,inplace}
+
+    df = deepcopy(x) # how to get correct output type here cache.returntype
+
+    if fdtype == Val(:central)
+        @inbounds for i ∈ eachindex(x)
+            epsilon = compute_epsilon(fdtype, x[i], relstep, absstep, dir)
+            c1 = f(setindex(x,x[i]+epsilon ,i))
+            c2 = f(setindex(x,x[i]-epsilon ,i))
+            dfi = (c1-c2)/(2epsilon)
+            df = setindex(df,dfi,i)
+        end
+    else
+        fdtype_error(returntype)
+    end
+    df
+end
 function finite_difference_gradient!(
     df,
     f,


### PR DESCRIPTION
Prototype of a version that is `Zygote` (nested differentiation) and `StaticArrays` compatible to fix https://github.com/JuliaDiff/FiniteDiff.jl/issues/148 .
This works as long as the input element type and the output type are the same.
Could use some advice on how to convert the element type of an arbitrary array to the correct output type.

Quite a bit of performance might be sacrificed for this generalization.

This approach differs from how this is handled in `ForwardDiff`, where there is a special dispatch for `StaticArrays`, and it is assumed that any other `AbstractArray` is able to handle mutation or gets transformed into a similar mutable array, and `Zygote` is (or should be) handled by a custom rule.