### PR TITLE
move StaticArrays to extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [weakdeps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 FiniteDiffBandedMatricesExt = "BandedMatrices"
 FiniteDiffBlockBandedMatricesExt = "BlockBandedMatrices"
+FiniteDiffStaticArraysExt = "StaticArrays"
 
 [compat]
 ArrayInterface = "7"
@@ -33,4 +35,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "BlockBandedMatrices", "BandedMatrices", "Pkg", "SafeTestsets"]
+test = ["Test", "BlockBandedMatrices", "BandedMatrices", "Pkg", "SafeTestsets", "StaticArrays"]

--- a/ext/FiniteDiffStaticArraysExt.jl
+++ b/ext/FiniteDiffStaticArraysExt.jl
@@ -1,0 +1,13 @@
+module FiniteDiffStaticArraysExt
+
+if isdefined(Base, :get_extension)
+    using FiniteDiff: FiniteDiff, ArrayInterface
+    using StaticArrays
+else
+    using ..FiniteDiff: FiniteDiff, ArrayInterface
+    using ..StaticArrays
+end
+FiniteDiff._mat(x::StaticVector)   = reshape(x, (axes(x, 1),     SOneTo(1)))
+FiniteDiff.setindex(x::StaticArray, v, i::Int...) = StaticArrays.setindex(x, v, i...)
+
+end #module

--- a/ext/FiniteDiffStaticArraysExt.jl
+++ b/ext/FiniteDiffStaticArraysExt.jl
@@ -9,5 +9,6 @@ else
 end
 FiniteDiff._mat(x::StaticVector)   = reshape(x, (axes(x, 1),     SOneTo(1)))
 FiniteDiff.setindex(x::StaticArray, v, i::Int...) = StaticArrays.setindex(x, v, i...)
+FiniteDiff.__Symmetric(x::SMatrix) = Symmetric(SArray(H))
 
 end #module

--- a/src/FiniteDiff.jl
+++ b/src/FiniteDiff.jl
@@ -1,6 +1,6 @@
 module FiniteDiff
 
-using LinearAlgebra, SparseArrays, StaticArrays, ArrayInterface, Requires
+using LinearAlgebra, SparseArrays, ArrayInterface, Requires
 
 import Base: resize!
 
@@ -8,12 +8,10 @@ _vec(x) = vec(x)
 _vec(x::Number) = x
 
 _mat(x::AbstractMatrix) = x
-_mat(x::StaticVector)   = reshape(x, (axes(x, 1),     SOneTo(1)))
 _mat(x::AbstractVector) = reshape(x, (axes(x, 1), Base.OneTo(1)))
 
 # Setindex overloads without piracy
 setindex(x...) = Base.setindex(x...)
-setindex(x::StaticArray, v, i::Int...) = StaticArrays.setindex(x, v, i...)
 
 function setindex(x::AbstractArray, v, i...)
     _x = Base.copymutable(x)
@@ -39,6 +37,8 @@ include("jacobians.jl")
 include("hessians.jl")
 
 if !isdefined(Base,:get_extension)
+    using StaticArrays
+    include("../ext/FiniteDiffStaticArraysExt.jl")
     using Requires
     function __init__()
         @require BandedMatrices="aae01518-5342-5314-be14-df237901396f" begin

--- a/src/hessians.jl
+++ b/src/hessians.jl
@@ -5,16 +5,19 @@ struct HessianCache{T,fdtype,inplace}
     xmm::T
 end
 
+_hessian_inplace(::Type{T}) where T = Val(ArrayInterface.ismutable(T))
+_hessian_inplace(x) = _hessian_inplace(typeof(x))
+
 function HessianCache(xpp,xpm,xmp,xmm,
                       fdtype=Val(:hcentral),
-                      inplace = x isa StaticArray ? Val(false) : Val(true))
+                      inplace = _hessian_inplace(x))
     fdtype isa Type && (fdtype = fdtype())
     inplace isa Type && (inplace = inplace())
     HessianCache{typeof(xpp),fdtype,inplace}(xpp,xpm,xmp,xmm)
 end
 
 function HessianCache(x, fdtype=Val(:hcentral),
-                      inplace = x isa StaticArray ? Val(false) : Val(true))
+                      inplace = _hessian_inplace(x))
     cx = copy(x)
     fdtype isa Type && (fdtype = fdtype())
     inplace isa Type && (inplace = inplace())
@@ -23,7 +26,7 @@ end
 
 function finite_difference_hessian(f, x,
     fdtype  = Val(:hcentral),
-    inplace = x isa StaticArray ? Val(false) : Val(true);
+    inplace = _hessian_inplace(x);
     relstep = default_relstep(fdtype, eltype(x)),
     absstep = relstep)
 
@@ -45,7 +48,7 @@ end
 function finite_difference_hessian!(H,f,
     x,
     fdtype  = Val(:hcentral),
-    inplace = x isa StaticArray ? Val(false) : Val(true);
+    inplace = _hessian_inplace(x);
     relstep=default_relstep(fdtype, eltype(x)),
     absstep=relstep)
 

--- a/src/hessians.jl
+++ b/src/hessians.jl
@@ -50,7 +50,6 @@ function finite_difference_hessian(
     H = mutable_zeromatrix(x)
     finite_difference_hessian!(H, f, x, cache; relstep=relstep, absstep=absstep)
     __Symmetric(H)
-    Symmetric(H isa SMatrix ? SArray(H) : H)
 end
 
 function finite_difference_hessian!(H,f,


### PR DESCRIPTION
there is a lot of `x isa StaticArray ? Val(false) : Val(true)`. those were replaced by a wrapper to `ArrayInterface.ismutable`