### PR TITLE
Remove `@inbounds` for structured matrices

### DIFF
--- a/ext/FiniteDiffBandedMatricesExt.jl
+++ b/ext/FiniteDiffBandedMatricesExt.jl
@@ -16,9 +16,9 @@ FiniteDiff._use_findstructralnz(::BandedMatrices.BandedMatrix) = false
     nrows = size(Jac,1)
     l,u = BandedMatrices.bandwidths(Jac)
     #data = BandedMatrices.bandeddata(Jac)
-    @inbounds for col_index in max(1,1-l):min(ncols,ncols+u)
+    for col_index in max(1,1-l):min(ncols,ncols+u)
         if colorvec[col_index] == color_i
-            @inbounds for row_index in max(1,col_index-u):min(nrows,col_index+l)
+            for row_index in max(1,col_index-u):min(nrows,col_index+l)
                 #data[u+row_index-col_index+1,col_index] = vfx[row_index]
                 Jac[row_index,col_index]=vfx[row_index]
             end

--- a/ext/FiniteDiffBlockBandedMatricesExt.jl
+++ b/ext/FiniteDiffBlockBandedMatricesExt.jl
@@ -21,18 +21,18 @@ FiniteDiff._use_findstructralnz(::BlockBandedMatrices.BlockBandedMatrix) = false
     cs = BlockArrays.blocklengths(BlockArrays.axes(Jac,1))
     b = BlockBandedMatrices.BlockArray(vfx,rs)
     c = BlockBandedMatrices.BlockArray(colorvec,cs)
-    @inbounds for J=BlockArrays.blockaxes(Jac,2)
+    for J=BlockArrays.blockaxes(Jac,2)
         c_v = c.blocks[J.n[1]]
-        @inbounds for K=BlockBandedMatrices.blockcolrange(Jac,J)
+        for K=BlockBandedMatrices.blockcolrange(Jac,J)
             V = view(Jac,K,J)
             b_v = b.blocks[K.n[1]]
             data = BlockBandedMatrices.bandeddata(V)
             p = pointer(data)
             st = stride(data,2)
             m,n = size(V)
-            @inbounds for j=1:n
+            for j=1:n
                 if c_v[j] == color_i
-                    @inbounds for k=max(1,j-μ):min(m,j+λ)
+                    for k=max(1,j-μ):min(m,j+λ)
                         unsafe_store!(p, b_v[k], (j-1)*st + μ + k - j + 1)
                     end
                 end
@@ -48,17 +48,17 @@ end
     cs = BlockArrays.blocklengths(BlockArrays.axes(Jac,1))
     b = BlockBandedMatrices.BlockArray(vfx,rs)
     c = BlockBandedMatrices.BlockArray(colorvec,cs)
-    @inbounds for J=BlockArrays.blockaxes(Jac,2)
+    for J=BlockArrays.blockaxes(Jac,2)
         c_v = c.blocks[J.n[1]]
         blockcolrange = BlockBandedMatrices.blockcolrange(Jac,J)
         _,n = length.(getindex.(axes(Jac), (blockcolrange[1], J)))
-        @inbounds for j = 1:n
+        for j = 1:n
             if c_v[j] == color_i
-                @inbounds for K = blockcolrange
+                for K = blockcolrange
                     V = view(Jac,K,J)
                     b_v = b.blocks[K.n[1]]
                     m = size(V,1)
-                    @inbounds for k = 1:m
+                    for k = 1:m
                         V[k,j] = b_v[k]
                     end
                 end

--- a/ext/FiniteDiffSparseArraysExt.jl
+++ b/ext/FiniteDiffSparseArraysExt.jl
@@ -18,9 +18,9 @@ function FiniteDiff._make_Ji(::SparseMatrixCSC, xtype, dx, color_i, nrows, ncols
 end
 
 @inline function FiniteDiff._colorediteration!(J, sparsity::SparseMatrixCSC, rows_index, cols_index, vfx, colorvec, color_i, ncols)
-    @inbounds for col_index in 1:ncols
+    for col_index in 1:ncols
         if colorvec[col_index] == color_i
-            @inbounds for row_index in view(sparsity.rowval, sparsity.colptr[col_index]:sparsity.colptr[col_index+1]-1)
+            for row_index in view(sparsity.rowval, sparsity.colptr[col_index]:sparsity.colptr[col_index+1]-1)
                 J[row_index, col_index] = vfx[row_index]
             end
         end
@@ -36,9 +36,9 @@ end
 # iteration_utils.jl
 ## fast version for the case where J and sparsity have the same sparsity pattern
 @inline function FiniteDiff._colorediteration!(Jsparsity::SparseMatrixCSC, vfx, colorvec, color_i, ncols)
-    @inbounds for col_index in 1:ncols
+    for col_index in 1:ncols
         if colorvec[col_index] == color_i
-            @inbounds for spidx in nzrange(Jsparsity, col_index)
+            for spidx in nzrange(Jsparsity, col_index)
                 row_index = Jsparsity.rowval[spidx]
                 Jsparsity.nzval[spidx] = vfx[row_index]
             end

--- a/src/iteration_utils.jl
+++ b/src/iteration_utils.jl
@@ -1,5 +1,5 @@
 @inline function _colorediteration!(J,sparsity,rows_index,cols_index,vfx,colorvec,color_i,ncols)
-    @inbounds for i in 1:length(cols_index)
+    for i in 1:length(cols_index)
         if colorvec[cols_index[i]] == color_i
             J[rows_index[i],cols_index[i]] = vfx[rows_index[i]]
         end


### PR DESCRIPTION
In general, `@inbounds` [should not be used](https://docs.julialang.org/en/v1/base/base/#Base.@inbounds) unless the indices have been properly checked, and the functions I modify here don't use `eachindex` or check the validity of ranges. Thus, they are unsafe, and this can lead to very weird behavior as we have seen in https://github.com/SciML/NonlinearSolve.jl/issues/473.