### PR TITLE
Generalize fast colored iteration on banded matrix to array output

### DIFF
--- a/ext/FiniteDiffBandedMatricesExt.jl
+++ b/ext/FiniteDiffBandedMatricesExt.jl
@@ -10,11 +10,11 @@ end
 
 FiniteDiff._use_findstructralnz(::BandedMatrices.BandedMatrix) = false
 
-@inline function FiniteDiff._colorediteration!(Jac::BandedMatrices.BandedMatrix,
+@inline function FiniteDiff._colorediteration!(Jac::Union{BandedMatrices.BandedMatrix,Array},
                                     sparsity::BandedMatrices.BandedMatrix,
                                     rows_index,cols_index,vfx,colorvec,color_i,ncols)
     nrows = size(Jac,1)
-    l,u = BandedMatrices.bandwidths(Jac)
+    l,u = BandedMatrices.bandwidths(sparsity)
     #data = BandedMatrices.bandeddata(Jac)
     for col_index in max(1,1-l):min(ncols,ncols+u)
         if colorvec[col_index] == color_i


### PR DESCRIPTION
The function already uses 2D indexing so it's fast and safe for array output too, it just needs to make sure to get the sparsity information from sparsity (which it should have done in the first place, it just assumed the two were the same).