### PR TITLE
Update Docs: Replace `SparseDiffTools.jl` with `SparseConnectivityTracer.jl` and `SparseMatrixColorings.jl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ Coloring vectors are allowed to be supplied to the Jacobian routines, and these 
 the directional derivatives for constructing the Jacobian. For example, an accurate
 NxN tridiagonal Jacobian can be computed in just 4 `f` calls by using
 `colorvec=repeat(1:3,N÷3)`. For information on automatically generating coloring
-vectors of sparse matrices, see [SparseDiffTools.jl](https://github.com/JuliaDiff/SparseDiffTools.jl).
-
-Hessian coloring support is coming soon!
+vectors of sparse matrices, see [SparseMatrixColorings.jl](https://github.com/gdalle/SparseMatrixColorings.jl) and 
+the now deprecated [SparseDiffTools.jl](https://github.com/JuliaDiff/SparseDiffTools.jl).
 
 ## Contributing
 

--- a/docs/src/jacobians.md
+++ b/docs/src/jacobians.md
@@ -14,7 +14,7 @@ Jacobians support the following function signatures:
 FiniteDiff.jl provides efficient sparse Jacobian computation using graph coloring:
 
 - Pass a `colorvec` of matrix colors to enable column compression
-- Provide `sparsity` as a sparse or structured matrix (`Tridiagonal`, `Banded`, etc.)
+- Provide `sparsity` as a sparse (`SparseMatrixCSC`) or structured matrix (`Tridiagonal`, `Banded`, etc.)
 - Supports automatic sparsity pattern detection via ArrayInterfaceCore.jl
 - Results are automatically decompressed unless `sparsity=nothing`
 

--- a/docs/src/jacobians.md
+++ b/docs/src/jacobians.md
@@ -14,7 +14,8 @@ Jacobians support the following function signatures:
 FiniteDiff.jl provides efficient sparse Jacobian computation using graph coloring:
 
 - Pass a `colorvec` of matrix colors to enable column compression
-- Provide `sparsity` as a sparse (`SparseMatrixCSC`) or structured matrix (`Tridiagonal`, `Banded`, etc.)
+- Provide `sparsity` as a sparse (e.g. the default `SparseMatrixCSC`) 
+  or structured matrix (`Tridiagonal`, `Banded`, etc.)
 - Supports automatic sparsity pattern detection via ArrayInterfaceCore.jl
 - Results are automatically decompressed unless `sparsity=nothing`
 


### PR DESCRIPTION
Due to deprecation of `SparseDiffTools.jl`