### PR TITLE
Make JVPCache immutable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDiff"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.31.0"
+version = "2.31.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/jvp.jl
+++ b/src/jvp.jl
@@ -11,7 +11,7 @@ and `v` is a vector.
 - `x1::X1`: Temporary array for perturbed input values
 - `fx1::FX1`: Temporary array for function evaluations
 """
-mutable struct JVPCache{X1, FX1, FDType}
+struct JVPCache{X1, FX1, FDType}
     x1::X1
     fx1::FX1
 end


### PR DESCRIPTION
From what I see in `src/jvp.jl`, there is no operation of the form `cache.x1 = something`, only `cache.x1 .= something`, which doesn't require a mutable struct. Making it immutable would allow alloc-free static array support in https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1019