### PR TITLE
Mark the documented public API as public

### DIFF
--- a/src/FiniteDiff.jl
+++ b/src/FiniteDiff.jl
@@ -142,4 +142,17 @@ include("jacobians.jl")
 include("hessians.jl")
 include("jvp.jl")
 
+# Mark the documented user-facing API (the names rendered in the docs' `@docs`
+# blocks) as public. `public` is a keyword only on Julia 1.11+, so it is emitted
+# via `eval` guarded on the version to keep this source parseable on the 1.10 LTS.
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Expr(:public,
+        :finite_difference_derivative, :finite_difference_derivative!,
+        :finite_difference_gradient, :finite_difference_gradient!,
+        :finite_difference_jacobian, :finite_difference_jacobian!,
+        :finite_difference_hessian, :finite_difference_hessian!,
+        :finite_difference_jvp, :finite_difference_jvp!,
+        :DerivativeCache, :GradientCache, :JacobianCache, :HessianCache, :JVPCache))
+end
+
 end # module

--- a/test/public_api_tests.jl
+++ b/test/public_api_tests.jl
@@ -1,0 +1,27 @@
+using FiniteDiff, Test
+
+# The documented user-facing API: every name rendered in a `@docs` block in the
+# manual. These must be reachable and, on Julia 1.11+, marked `public` so that
+# downstream packages' ExplicitImports/Aqua qualified-access checks pass.
+const PUBLIC_API = (
+    :finite_difference_derivative, :finite_difference_derivative!,
+    :finite_difference_gradient, :finite_difference_gradient!,
+    :finite_difference_jacobian, :finite_difference_jacobian!,
+    :finite_difference_hessian, :finite_difference_hessian!,
+    :finite_difference_jvp, :finite_difference_jvp!,
+    :DerivativeCache, :GradientCache, :JacobianCache, :HessianCache, :JVPCache,
+)
+
+@testset "Public API is defined" begin
+    for name in PUBLIC_API
+        @test isdefined(FiniteDiff, name)
+    end
+end
+
+@static if VERSION >= v"1.11.0-DEV.469"
+    @testset "Public API is marked public" begin
+        for name in PUBLIC_API
+            @test Base.ispublic(FiniteDiff, name)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ end
 @time begin
 
 if GROUP == "All" || GROUP == "Core"
+  @time @safetestset "Public API Tests" begin include("public_api_tests.jl") end
   @time @safetestset "FiniteDiff Standard Tests" begin include("finitedifftests.jl") end
   @time @safetestset "Color Differentiation Tests" begin include("coloring_tests.jl") end
   @time @safetestset "Out of Place Tests" begin include("out_of_place_tests.jl") end


### PR DESCRIPTION
## Summary

FiniteDiff exports nothing and declared no `public` names, so every documented entry point is only reachable via qualified access (`FiniteDiff.finite_difference_jacobian`, etc.). On Julia 1.11+ this trips downstream `ExplicitImports`/`Aqua` qualified-access checks, which flag these as accesses to **non-public** names.

Concretely, this surfaced as a QA failure in [SimpleBoundaryValueDiffEq.jl](https://github.com/SciML/SimpleBoundaryValueDiffEq.jl/actions/runs/29180689018/job/86617688416?pr=58), where `check_all_qualified_accesses_are_public` reported:

```
- finite_difference_jacobian is not public in FiniteDiff
- finite_difference_jacobian! is not public in FiniteDiff
```

## Change

Declare the **15** names that are rendered in the manual's `@docs` blocks as `public`:

- `finite_difference_derivative`, `finite_difference_derivative!`
- `finite_difference_gradient`, `finite_difference_gradient!`
- `finite_difference_jacobian`, `finite_difference_jacobian!`
- `finite_difference_hessian`, `finite_difference_hessian!`
- `finite_difference_jvp`, `finite_difference_jvp!`
- `DerivativeCache`, `GradientCache`, `JacobianCache`, `HessianCache`, `JVPCache`

`public` is a keyword only on Julia 1.11+, so it is emitted via `eval(Expr(:public, ...))` guarded on `VERSION` to keep the source parseable on the 1.10 LTS. Names described only in prose on the "Internal Utilities" docs page (the `_`-prefixed helpers) are intentionally left non-public.

A `test/public_api_tests.jl` asserts each name is defined and, on 1.11+, marked public.

## Verification

- Loads cleanly and all 15 names test `Base.ispublic == true` on Julia 1.11; loads cleanly on the 1.10 LTS (guard skips the `public` emit).
- Reproduced the downstream check end-to-end: with unpatched FiniteDiff, `improper_qualified_accesses(SimpleBoundaryValueDiffEq)` lists both `finite_difference_jacobian` names; with this patch dev'd in, they no longer appear. (SBVDE separately still accesses `Base.Iterators.peel`, which is unrelated to FiniteDiff.)

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)