### PR TITLE
Fix spurious allocations in ret_allocs test helper on Julia 1.10/1.11

### DIFF
--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -344,7 +344,11 @@ central_cache = FiniteDiff.GradientCache(df, x, Val{:central})
     @test err_func(FiniteDiff.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 3e-7
 end
 
-function ret_allocs(res, _f, x, cache)
+# Force specialization on the function argument. Without `::F where {F}`, Julia
+# does not specialize this helper on `_f` (a bare Function it only forwards), so
+# the inner call dispatches dynamically and the wrapper itself allocates ~48
+# bytes on 1.10/1.11 (0 on 1.12+) — a measurement artifact, not library work.
+function ret_allocs(res, _f::F, x, cache) where {F}
     allocs = @allocated FiniteDiff.finite_difference_gradient!(res, _f, x, cache)
     allocs
 end


### PR DESCRIPTION
## Summary

The "Non-allocating cache construction" testset (`test/finitedifftests.jl`) currently **fails on Julia 1.10 and 1.11** with 12 `Evaluated: 48 == 0` failures at `:371`/`:379`. It passes on Julia 1.12. This is a **test-helper artifact, not a library regression** — the `finite_difference_gradient!` path is genuinely allocation-free.

## Root cause

```julia
function ret_allocs(res, _f, x, cache)
    @allocated FiniteDiff.finite_difference_gradient!(res, _f, x, cache)
end
```

Julia's default heuristic does not specialize a method on a `Function`-typed argument that is only forwarded to an inner call. So `_f` is boxed inside `ret_allocs`, the inner `finite_difference_gradient!` becomes a dynamic dispatch, and the **wrapper itself** allocates ~48 bytes on 1.10/1.11 (0 on 1.12+, where the heuristic improved). The library work is 0 bytes.

Independently verified the library allocates nothing:
- `@allocated` inside a function around the call = `0`
- 1000 direct calls measured via `Base.gc_bytes()` = `0` total
- `Profile.Allocs` on a normally-compiled call = `0` allocations

## Fix

Force specialization on the function argument:

```julia
function ret_allocs(res, _f::F, x, cache) where {F}
    @allocated FiniteDiff.finite_difference_gradient!(res, _f, x, cache)
end
```

## Verification

Ran the full Core suite locally on Julia 1.11: `FiniteDiff Standard Tests | 219 pass, 0 fail, 1 broken` → `Testing FiniteDiff tests passed` (previously 207 pass / 12 fail / 1 broken).

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)