### PR TITLE
Make the out-of-place jacobian's return type inferrable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDiff"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.32.0"
+version = "2.32.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -294,14 +294,17 @@ function finite_difference_jacobian(
         copyto!(x1, x)
     end
 
-    if !(f_in isa Nothing)
-        vecfx = _vec(f_in)
+    # Single assignment site: `vecfx` is captured by the `calculate_Ji_*` closures
+    # below, and a captured variable with several assignment sites is boxed, which
+    # makes the whole function's return type uninferrable.
+    vecfx = if !(f_in isa Nothing)
+        _vec(f_in)
     elseif fdtype == Val(:forward)
-        vecfx = _vec(f(x))
+        _vec(f(x))
     elseif fdtype == Val(:complex) && returntype <: Real
-        vecfx = real(fx)
+        real(fx)
     else
-        vecfx = _vec(fx)
+        _vec(fx)
     end
     vecx = _vec(x)
     J = jac_prototype isa Nothing ?
@@ -310,13 +313,16 @@ function finite_difference_jacobian(
     nrows, ncols = size(J)
 
     if !(sparsity isa Nothing)
-        rows_index, cols_index = ArrayInterface.findstructralnz(sparsity)
-        rows_index = [rows_index[i] for i in 1:length(rows_index)]
-        cols_index = [cols_index[i] for i in 1:length(cols_index)]
+        structural_rows, structural_cols = ArrayInterface.findstructralnz(sparsity)
+        rows_index = [structural_rows[i] for i in 1:length(structural_rows)]
+        cols_index = [structural_cols[i] for i in 1:length(structural_cols)]
     end
 
     if fdtype == Val(:forward)
+        # `local` keeps these from aliasing (and thereby boxing) the same-named
+        # variables of the enclosing function; see the `vecfx` comment above.
         function calculate_Ji_forward(i)
+            local x_save, epsilon, _vecx1, _x1, vecfx1, dx
             x_save = ArrayInterface.allowed_getindex(vecx, i)
             epsilon = compute_epsilon(Val(:forward), x_save, relstep, absstep, dir)
             _vecx1 = setindex(vecx, x_save+epsilon, i)
@@ -336,12 +342,12 @@ function finite_difference_jacobian(
                     J = J + _make_Ji(J, eltype(x), dx, color_i, nrows, ncols)
                 else
                     tmp = norm(vecx .* (colorvec .== color_i))
-                    epsilon = compute_epsilon(
+                    epsilon_c = compute_epsilon(
                         Val(:forward), sqrt(tmp), relstep, absstep, dir)
-                    _vecx = @. vecx + epsilon * (colorvec == color_i)
+                    _vecx = @. vecx + epsilon_c * (colorvec == color_i)
                     _x = reshape(_vecx, axes(x))
                     vecfx1 = _vec(f(_x))
-                    dx = (vecfx1-vecfx)/epsilon
+                    dx = (vecfx1-vecfx)/epsilon_c
                     Ji = _make_Ji(
                         J, rows_index, cols_index, dx, colorvec, color_i, nrows, ncols)
                     J = J + Ji
@@ -354,6 +360,7 @@ function finite_difference_jacobian(
         # unsafe — the cache may have been built via `similar(x)` or reused at a
         # different x — so we always perturb around `vecx` directly.
         function calculate_Ji_central(i)
+            local x_save, epsilon, _vecx1, _vecx, _x1, _x, vecfx1, vecfx0, dx
             x_save = ArrayInterface.allowed_getindex(vecx, i)
             epsilon = compute_epsilon(Val(:forward), x_save, relstep, absstep, dir)
             _vecx1 = setindex(vecx, x_save+epsilon, i)
@@ -361,8 +368,8 @@ function finite_difference_jacobian(
             _x1 = reshape(_vecx1, axes(x))
             _x = reshape(_vecx, axes(x))
             vecfx1 = _vec(f(_x1))
-            vecfx = _vec(f(_x))
-            dx = (vecfx1-vecfx)/(2epsilon)
+            vecfx0 = _vec(f(_x))
+            dx = (vecfx1-vecfx0)/(2epsilon)
             return dx
         end
 
@@ -376,15 +383,15 @@ function finite_difference_jacobian(
                     J = J + _make_Ji(J, eltype(x), dx, color_i, nrows, ncols)
                 else
                     tmp = norm(vecx .* (colorvec .== color_i))
-                    epsilon = compute_epsilon(
+                    epsilon_c = compute_epsilon(
                         Val(:forward), sqrt(tmp), relstep, absstep, dir)
-                    _vecx1 = @. vecx + epsilon * (colorvec == color_i)
-                    _vecx = @. vecx - epsilon * (colorvec == color_i)
+                    _vecx1 = @. vecx + epsilon_c * (colorvec == color_i)
+                    _vecx = @. vecx - epsilon_c * (colorvec == color_i)
                     _x1 = reshape(_vecx1, axes(x))
                     _x = reshape(_vecx, axes(x))
                     vecfx1 = _vec(f(_x1))
-                    vecfx = _vec(f(_x))
-                    dx = (vecfx1-vecfx)/(2epsilon)
+                    vecfx0 = _vec(f(_x))
+                    dx = (vecfx1-vecfx0)/(2epsilon_c)
                     Ji = _make_Ji(
                         J, rows_index, cols_index, dx, colorvec, color_i, nrows, ncols)
                     J = J + Ji
@@ -395,11 +402,12 @@ function finite_difference_jacobian(
         epsilon = eps(eltype(x))
 
         function calculate_Ji_complex(i)
+            local x_save, _vecx, _x, vecfx_c, dx
             x_save = ArrayInterface.allowed_getindex(vecx, i)
             _vecx = setindex(complex.(vecx), x_save+im*epsilon, i)
             _x = reshape(_vecx, axes(x))
-            vecfx = _vec(f(_x))
-            dx = imag(vecfx)/epsilon
+            vecfx_c = _vec(f(_x))
+            dx = imag(vecfx_c)/epsilon
             return dx
         end
 
@@ -414,8 +422,8 @@ function finite_difference_jacobian(
                 else
                     _vecx = @. vecx + im * epsilon * (colorvec == color_i)
                     _x = reshape(_vecx, axes(x))
-                    vecfx = _vec(f(_x))
-                    dx = imag(vecfx)/epsilon
+                    vecfx_c = _vec(f(_x))
+                    dx = imag(vecfx_c)/epsilon
                     Ji = _make_Ji(
                         J, rows_index, cols_index, dx, colorvec, color_i, nrows, ncols)
                     J = J + Ji

--- a/test/out_of_place_tests.jl
+++ b/test/out_of_place_tests.jl
@@ -55,3 +55,17 @@ J = FiniteDiff.finite_difference_jacobian(f, x, Val{:central}, eltype(x))
 J = FiniteDiff.finite_difference_jacobian(f, x, Val{:complex}, eltype(x))
 @test J ≈ fill(1.0, 2, 1)
 @test J isa SMatrix{2,1}
+
+# The per-color closures used to assign variables that also live in the enclosing
+# function's scope, which boxed the captures and made the return type `Any`.
+# Static-array inputs stay uninferrable here: the `mapreduce(_, hcat, _)` accumulator
+# grows one `SMatrix` column per color, so its type depends on `maximum(colorvec)`.
+@testset "Type stability of the dense out-of-place jacobian" begin
+  g(x) = x .^ 2 .- 2
+  x = [1.0, 2.0, 3.0]
+  @testset "$difftype" for difftype in (:forward, :central, :complex)
+    cache = FiniteDiff.JacobianCache(x, Val{difftype}, eltype(x))
+    @test (@inferred FiniteDiff.finite_difference_jacobian(g, x, cache)) ≈
+      Diagonal(2x)
+  end
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Closes https://github.com/SciML/NonlinearSolve.jl/issues/1092

### Problem

The out-of-place `finite_difference_jacobian` infers to `Any`:

```julia
julia> g(x) = x .^ 2 .- 2
julia> x = [1.0, 2.0, 3.0];
julia> cache = FiniteDiff.JacobianCache(x, Val{:forward}, eltype(x));
julia> Base.return_types(FiniteDiff.finite_difference_jacobian, typeof.((g, x, cache)))
1-element Vector{Any}:
 Any
```

The `calculate_Ji_forward` / `calculate_Ji_central` / `calculate_Ji_complex` closures assign
variables that also exist in the enclosing function's scope (`epsilon`, `vecfx`, `x_save`,
`dx`, ...). An inner function assigning a name that exists in the enclosing scope binds the
*outer* variable, so those became captured variables with several assignment sites — which
closure conversion boxes. Reading a boxed capture gives `Any`, and that propagates through
`mapreduce(calculate_Ji_*, hcat, ...)` to the returned matrix. `rows_index` / `cols_index`
had the same problem via the comprehension that reassigns them.

`@report_opt` on the FiniteDiff path, before:

```
captured variable `epsilon` detected
captured variable `vecfx` detected
captured variable `rows_index` detected
captured variable `cols_index` detected
runtime dispatch detected: op::typeof(hcat)(%69::Any, %70::Any)::Any
```

### Fix

Declare the closures' temporaries `local` so they stop aliasing the enclosing function's
variables, rename the few that had to stay distinct from a genuine capture, and give
`vecfx` / `rows_index` / `cols_index` a single assignment site each.

No behavioral change — the closures only ever wrote those outer variables incidentally, and
no branch read the values back afterwards.

After:

```julia
julia> Base.return_types(FiniteDiff.finite_difference_jacobian, typeof.((g, x, cache)))
1-element Vector{Any}:
 Matrix{Float64}
```

Static-array inputs stay uninferrable, which is a separate (and harder) problem: the `hcat`
accumulator gains one `SMatrix` column per color, so its type depends on the runtime value
of `maximum(colorvec)`. Noted in a comment next to the new test.

### Downstream motivation

This is the root cause of https://github.com/SciML/NonlinearSolve.jl/issues/1092 — the
Jacobian cache is typed by this return value, so the whole solver cache inferred to an open
`where`-bound:

```julia
using NonlinearSolve, ADTypes, SciMLBase
prob = NonlinearProblem((u, p) -> u .^ 2 .- 2.0, [1.0])
@inferred SciMLBase.init(prob, TrustRegion(autodiff = AutoFiniteDiff()))   # ERROR before, OK after
```

### Testing

Added an inference regression test to `test/out_of_place_tests.jl` covering all three
`fdtype`s. Ran the full `GROUP=Core` suite locally on Julia 1.10.11 — green:

```
Test Summary:    | Pass  Total  Time
Public API Tests |   15     15  0.2s
Test Summary:             | Pass  Broken  Total   Time
FiniteDiff Standard Tests |  219       1    220  35.6s
Test Summary:               | Pass  Total     Time
Color Differentiation Tests |   39     39  4m12.5s
Test Summary:      | Pass  Total   Time
Out of Place Tests |   28     28  40.1s
Test Summary:            | Pass  Total  Time
Cache Reuse Safety Tests |   27     27  4.5s
```

(the one `Broken` is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoeiVWqAEFJQK22kiXu48f